### PR TITLE
Check status on read

### DIFF
--- a/PCA95x5.h
+++ b/PCA95x5.h
@@ -148,7 +148,7 @@ private:
     int8_t read_bytes(const uint8_t dev, const uint8_t reg, uint8_t* data, const uint8_t size) {
         wire->beginTransmission(dev);
         wire->write(reg);
-        wire->endTransmission();
+        status = wire->endTransmission();
         wire->requestFrom(dev, size);
         int8_t count = 0;
         while (wire->available()) data[count++] = wire->read();


### PR DESCRIPTION
When performing a read_bytes(), the status is not updated, therefore the i2c_error is not populated in the event the PCA95x5 falls off the bus after being attached.  This status _is_ updated when write_bytes is called, so it looks like an oversight.